### PR TITLE
Add User.GetAccountBatch and Sharing.ListSharedFileMembers

### DIFF
--- a/sharing.go
+++ b/sharing.go
@@ -59,6 +59,14 @@ func (c *Sharing) CreateSharedLink(in *CreateSharedLinkInput) (out *CreateShared
 	return
 }
 
+// ListSharedFileMembersInput request input.
+type ListSharedFileMembersInput struct {
+	File             string         `json:"file"`
+	Actions          []MemberAction `json:"actions"`
+	IncludeInherited bool           `json:"include_inherited"`
+	Limit            uint32         `json:"limit"`
+}
+
 // ListSharedFolderMembersInput request input.
 type ListSharedFolderMembersInput struct {
 	SharedFolderID string         `json:"shared_folder_id"`
@@ -66,12 +74,17 @@ type ListSharedFolderMembersInput struct {
 	Limit          uint64         `json:"limit"`
 }
 
-// ListSharedFolderMembersOutput enumerates shared folder user and group membership.
-type ListSharedFolderMembersOutput struct {
+// ListSharedMembersOutput enumerates shared file/folder user and group membership.
+type ListSharedMembersOutput struct {
 	Users    []UserMembershipInfo    `json:"users"`
 	Groups   []GroupMembershipInfo   `json:"groups"`
 	Invitees []InviteeMembershipInfo `json:"invitees"`
 	Cursor   string                  `json:"cursor"`
+}
+
+// ListSharedMembersContinueInput is the input for continuing listing file/folder members.
+type ListSharedMembersContinueInput struct {
+	Cursor string `json:"cursor"`
 }
 
 // UserMembershipInfo is information about a user member of the shared folder.
@@ -172,8 +185,32 @@ type InviteeInfo struct {
 	Email string `json:"email"`
 }
 
+// ListSharedFileMembers returns shared file membership by its file ID.
+func (c *Sharing) ListSharedFileMembers(in *ListSharedFileMembersInput) (out *ListSharedMembersOutput, err error) {
+	body, err := c.call("/sharing/list_file_members", in)
+	if err != nil {
+		return
+	}
+	defer body.Close()
+
+	err = json.NewDecoder(body).Decode(&out)
+	return
+}
+
+// ListSharedFileMembersContinue returns shared file membership by its file ID.
+func (c *Sharing) ListSharedFileMembersContinue(in *ListSharedMembersContinueInput) (out *ListSharedMembersOutput, err error) {
+	body, err := c.call("/sharing/list_file_members/continue", in)
+	if err != nil {
+		return
+	}
+	defer body.Close()
+
+	err = json.NewDecoder(body).Decode(&out)
+	return
+}
+
 // ListSharedFolderMembers returns shared folder membership by its folder ID.
-func (c *Sharing) ListSharedFolderMembers(in *ListSharedFolderMembersInput) (out *ListSharedFolderMembersOutput, err error) {
+func (c *Sharing) ListSharedFolderMembers(in *ListSharedFolderMembersInput) (out *ListSharedMembersOutput, err error) {
 	body, err := c.call("/sharing/list_folder_members", in)
 	if err != nil {
 		return
@@ -184,13 +221,8 @@ func (c *Sharing) ListSharedFolderMembers(in *ListSharedFolderMembersInput) (out
 	return
 }
 
-// ListSharedFolderMembersInputContinue is the input for continuing listing folder members.
-type ListSharedFolderMembersInputContinue struct {
-	Cursor string `json:"cursor"`
-}
-
 // ListSharedFolderMembersContinue returns shared folder membership by its folder ID.
-func (c *Sharing) ListSharedFolderMembersContinue(in *ListSharedFolderMembersInputContinue) (out *ListSharedFolderMembersOutput, err error) {
+func (c *Sharing) ListSharedFolderMembersContinue(in *ListSharedMembersContinueInput) (out *ListSharedMembersOutput, err error) {
 	body, err := c.call("/sharing/list_folder_members/continue", in)
 	if err != nil {
 		return

--- a/sharing_test.go
+++ b/sharing_test.go
@@ -49,7 +49,7 @@ func TestSharing_ListSharedFolder(t *testing.T) {
 		assert.Equal(t, 1, len(out.Users)+len(out.Groups)+len(out.Invitees), "there should be 1 item present")
 
 		for out.Cursor != "" {
-			out, err = c.Sharing.ListSharedFolderMembersContinue(&ListSharedFolderMembersInputContinue{
+			out, err = c.Sharing.ListSharedFolderMembersContinue(&ListSharedMembersContinueInput{
 				Cursor: out.Cursor,
 			})
 
@@ -57,4 +57,24 @@ func TestSharing_ListSharedFolder(t *testing.T) {
 			assert.Equal(t, 1, len(out.Users)+len(out.Groups)+len(out.Invitees), "there should be 1 item present")
 		}
 	}
+}
+
+func TestSharing_ListSharedFile(t *testing.T) {
+	c := client()
+	out, err := c.Sharing.ListSharedFileMembers(&ListSharedFileMembersInput{
+		File:             "/hello.txt",
+		IncludeInherited: true,
+		Limit:            1,
+	})
+
+	assert.NoError(t, err, "getting shared user list")
+	assert.NotEmpty(t, out.Users, "output should be non-empty")
+	assert.NotEmpty(t, out.Cursor, "cursor should be non-empty for complete test")
+
+	out, err = c.Sharing.ListSharedFileMembersContinue(&ListSharedMembersContinueInput{
+		Cursor: out.Cursor,
+	})
+
+	assert.NoError(t, err, "continuing shared user list")
+	assert.NotZero(t, len(out.Users)+len(out.Groups)+len(out.Invitees), "continuing list should be non-empty")
 }

--- a/users.go
+++ b/users.go
@@ -46,6 +46,26 @@ func (c *Users) GetAccount(in *GetAccountInput) (out *GetAccountOutput, err erro
 	return
 }
 
+// GetAccountBatchInput request input. At most 300 ids may be listed.
+type GetAccountBatchInput struct {
+	AccountIDs []string `json:"account_ids"`
+}
+
+// GetAccountBatchOutput request output.
+type GetAccountBatchOutput []*GetAccountOutput
+
+// GetAccountBatch returns a list of information about users' accounts.
+func (c *Users) GetAccountBatch(in *GetAccountBatchInput) (out GetAccountBatchOutput, err error) {
+	body, err := c.call("/users/get_account_batch", in)
+	if err != nil {
+		return
+	}
+	defer body.Close()
+
+	err = json.NewDecoder(body).Decode(&out)
+	return
+}
+
 // GetCurrentAccountOutput request output.
 type GetCurrentAccountOutput struct {
 	AccountID string `json:"account_id"`

--- a/users_test.go
+++ b/users_test.go
@@ -11,3 +11,19 @@ func TestUsers_GetCurrentAccount(t *testing.T) {
 	_, err := c.Users.GetCurrentAccount()
 	assert.NoError(t, err)
 }
+
+func TestUsers_GetAccountBatch(t *testing.T) {
+	c := client()
+	setup, err := c.Users.GetCurrentAccount()
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, setup.AccountID, "account id required for test setup")
+
+	out, err := c.Users.GetAccountBatch(&GetAccountBatchInput{
+		AccountIDs: []string{setup.AccountID},
+	})
+
+	assert.NoError(t, err, "getting account batch")
+	assert.NotEmpty(t, out, "account batch output")
+	assert.EqualValues(t, setup.AccountID, out[0].AccountID, "requested match retrieved")
+}


### PR DESCRIPTION
Added support for
- [`/list_file_members`](https://www.dropbox.com/developers/documentation/http/documentation#sharing-list_file_members)
- [`/list_file_members/continue`](https://www.dropbox.com/developers/documentation/http/documentation#sharing-list_file_members-continue)
- [`/get_account_batch`](https://www.dropbox.com/developers/documentation/http/documentation#users-get_account_batch)

Tests require the file `/hello.txt` to exist and be shared with two people.
