### PR TITLE
add email field to get account output

### DIFF
--- a/users.go
+++ b/users.go
@@ -32,6 +32,10 @@ type GetAccountOutput struct {
 		FamiliarName string `json:"familiar_name"`
 		DisplayName  string `json:"display_name"`
 	} `json:"name"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	Disabled      bool   `json:"disabled"`
+	IsTeammate    bool   `json:"is_teammate"`
 }
 
 // GetAccount returns information about a user's account.


### PR DESCRIPTION
Add more fields from the response to [`/get_account`](https://www.dropbox.com/developers/documentation/http/documentation#users-get_account)
