### PR TITLE
expanded error type with tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -86,6 +86,7 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, int64, error) {
 	e := &Error{
 		Status:     http.StatusText(res.StatusCode),
 		StatusCode: res.StatusCode,
+		Header:     res.Header,
 	}
 
 	kind := res.Header.Get("Content-Type")
@@ -94,9 +95,8 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, int64, error) {
 		if b, err := ioutil.ReadAll(res.Body); err == nil {
 			e.Summary = string(b)
 			return nil, 0, e
-		} else {
-			return nil, 0, err
 		}
+		return nil, 0, err
 	}
 
 	if err := json.NewDecoder(res.Body).Decode(e); err != nil {

--- a/error.go
+++ b/error.go
@@ -1,13 +1,45 @@
 package dropbox
 
+import (
+	"net/http"
+)
+
+// error tag constant values
+const (
+	TooManyRequests = "too_many_requests"
+)
+
 // Error response.
 type Error struct {
 	Status     string
 	StatusCode int
-	Summary    string `json:"error_summary"`
+	Header     http.Header
+	Summary    string                 `json:"error_summary"`
+	Message    string                 `json:"user_message"` // optionally present
+	Err        map[string]interface{} `json:"error"`
 }
 
 // Error string.
 func (e *Error) Error() string {
 	return e.Summary
+}
+
+// Tag returns the inner tag for the error
+func (e *Error) Tag() (tag, value string) {
+	var ok bool
+	tag, ok = e.Err[".tag"].(string)
+	if !ok {
+		return
+	}
+
+	data, ok := e.Err[tag].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	value, ok = data[".tag"].(string)
+	if !ok {
+		return
+	}
+	return
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,26 @@
+package dropbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError(t *testing.T) {
+	c := client()
+	out, err := c.Files.GetMetadata(&GetMetadataInput{
+		Path: "/this/does/not/exist.txt",
+	})
+
+	assert.Nil(t, out, "no object should be returned on error")
+	assert.Error(t, err, "error should occur for nonexistant path")
+
+	derr, ok := err.(*Error)
+
+	assert.True(t, ok, "error should be a package error")
+	assert.NotNil(t, derr.Header, "error headers should be present")
+	assert.NotNil(t, derr.Err, "error detail should be present")
+	tag, value := derr.Tag()
+	assert.Equal(t, "path", tag, "error should indicate the path was invalid")
+	assert.Equal(t, "not_found", value, "error should indicate not found")
+}


### PR DESCRIPTION
Adds handling for the inner tag format [1] and HTTP headers to facilitate improved handling of rate limiting [2]

[1] https://www.dropbox.com/developers/reference/migration-guide#error-handling
[2] bottom of: https://www.dropbox.com/developers-v1/core/bestpractices
