### PR TITLE
add embedded type to handle media metadata redundancy

### DIFF
--- a/files.go
+++ b/files.go
@@ -43,17 +43,20 @@ type GPSCoordinates struct {
 
 // PhotoMetadata specifies metadata for a photo.
 type PhotoMetadata struct {
-	Dimensions *Dimensions     `json:"dimensions,omitempty"`
-	Location   *GPSCoordinates `json:"location,omitempty"`
-	TimeTaken  time.Time       `json:"time_taken,omitempty"`
+	VisualMediaMetadata
 }
 
 // VideoMetadata specifies metadata for a video.
 type VideoMetadata struct {
+	VisualMediaMetadata
+	Duration uint64 `json:"duration,omitempty"`
+}
+
+// VisualMediaMetadata specifies metadata common to photo and video
+type VisualMediaMetadata struct {
 	Dimensions *Dimensions     `json:"dimensions,omitempty"`
 	Location   *GPSCoordinates `json:"location,omitempty"`
 	TimeTaken  time.Time       `json:"time_taken,omitempty"`
-	Duration   uint64          `json:"duration,omitempty"`
 }
 
 // MediaMetadata provides metadata for a photo or video.


### PR DESCRIPTION
When handling `MediaMetadata` the two fields `Photo` and `Video` are mutually exclusive, yet require similar processing. 

With this PR we are able to handle `MediaMetadata` without writing redundant code. Example:

```
    var vm dropbox.VisualMediaMetadata

    if v := mediaMetadata.Video; v != nil {
        vm = v.VisualMediaMetadata

        // Handle Video specific fields

    } else if p := mediaMetadata.Photo; p != nil {
        vm = p.VisualMediaMetadata

        // Handle Photo specific fields (there are none)

    } else {
        // Nothing to do
        return
    }

    // Handle generic visual media fields
```
