### PR TITLE
restructure media metadata for successful unmarshalling

### DIFF
--- a/files.go
+++ b/files.go
@@ -43,26 +43,22 @@ type GPSCoordinates struct {
 
 // PhotoMetadata specifies metadata for a photo.
 type PhotoMetadata struct {
-	VisualMediaMetadata
 }
 
 // VideoMetadata specifies metadata for a video.
 type VideoMetadata struct {
-	VisualMediaMetadata
 	Duration uint64 `json:"duration,omitempty"`
-}
-
-// VisualMediaMetadata specifies metadata common to photo and video
-type VisualMediaMetadata struct {
-	Dimensions *Dimensions     `json:"dimensions,omitempty"`
-	Location   *GPSCoordinates `json:"location,omitempty"`
-	TimeTaken  time.Time       `json:"time_taken,omitempty"`
 }
 
 // MediaMetadata provides metadata for a photo or video.
 type MediaMetadata struct {
-	Photo *PhotoMetadata `json:"photo,omitempty"`
-	Video *VideoMetadata `json:"video,omitempty"`
+	Tag        string          `json:".tag"`
+	Dimensions *Dimensions     `json:"dimensions,omitempty"`
+	Location   *GPSCoordinates `json:"location,omitempty"`
+	TimeTaken  time.Time       `json:"time_taken,omitempty"`
+
+	PhotoMetadata
+	VideoMetadata
 }
 
 // MediaInfo provides additional information for a photo or video file.

--- a/files_test.go
+++ b/files_test.go
@@ -58,6 +58,19 @@ func TestFiles_GetMetadata(t *testing.T) {
 	assert.Equal(t, "file", out.Tag)
 }
 
+func TestFiles_GetMetadataWithMediaInfo(t *testing.T) {
+	c := client()
+
+	out, err := c.Files.GetMetadata(&GetMetadataInput{
+		Path:             "/IMG_0001.jpg",
+		IncludeMediaInfo: true,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "file", out.Tag)
+	assert.Equal(t, "photo", out.MediaInfo.Metadata.Tag)
+	assert.NotNil(t, out.MediaInfo.Metadata.Dimensions)
+}
+
 func TestFiles_ListFolder(t *testing.T) {
 	t.Parallel()
 	c := client()


### PR DESCRIPTION
working playground example https://play.golang.org/p/-_IdYi6X_g

The Dropbox documentation does not do a good job describing the structure of the `media_info` response. The current `media_info` structure matches the documentation but fails to work with the response. 

This PR allows for successful unmarshalling of the `media_info` field. 

The `PhotoMetadata` and `VideoMetadata` structs will make more sense once Dropbox supports more Exif data. Right now their usefulness is questionable. 

Do we want a test for this?

**EDIT**: Also, I think this is a breaking change.
