### PR TITLE
Config option to specify which namespace to send requests relative to

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,6 +42,13 @@ func (c *Client) call(path string, in interface{}) (io.ReadCloser, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
 	req.Header.Set("Content-Type", "application/json")
+	if c.Namespace != nil {
+		namespaceHeader, err := json.Marshal(c.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Dropbox-API-Path-Root", string(namespaceHeader))
+	}
 
 	r, _, err := c.do(req)
 	return r, err
@@ -62,6 +69,13 @@ func (c *Client) download(path string, in interface{}, r io.Reader) (io.ReadClos
 	}
 	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
 	req.Header.Set("Dropbox-API-Arg", string(body))
+	if c.Namespace != nil {
+		namespaceHeader, err := json.Marshal(c.Namespace)
+		if err != nil {
+			return nil, 0, err
+		}
+		req.Header.Set("Dropbox-API-Path-Root", string(namespaceHeader))
+	}
 
 	if r != nil {
 		req.Header.Set("Content-Type", "application/octet-stream")

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 type Config struct {
 	HTTPClient  *http.Client
 	AccessToken string
+	Namespace   *APIPathRoot
 }
 
 // NewConfig with the given access token.
@@ -16,4 +17,33 @@ func NewConfig(accessToken string) *Config {
 		HTTPClient:  http.DefaultClient,
 		AccessToken: accessToken,
 	}
+}
+
+// APIPathRoot is marshalled onto the Dropbox-API-Path-Root header to
+// indicate which namespace to send Dropbox API requests relative to.
+// doc: https://www.dropbox.com/developers/reference/namespace-guide
+type APIPathRoot struct {
+	Tag         string `json:".tag"`
+	NamespaceID string `json:"namespace_id,omitempty"`
+	Root        string `json:"root,omitempty"`
+}
+
+// HomeNamespace is a Dropbox-API-Path-Root header value used for specifying
+// that Dropbox API requests should be sent relative to a user's home
+// namespace.
+var HomeNamespace = &APIPathRoot{Tag: "home"}
+
+// NamespaceIDNamespace is a Dropbox-API-Path-Root header value used for
+// specifying that Dropbox API requests should be sent relative to the Dropbox
+// namespace passed in.
+func NamespaceIDNamespace(namespaceID string) *APIPathRoot {
+	return &APIPathRoot{Tag: "namespace_id", NamespaceID: namespaceID}
+}
+
+// RootNamespace is a Dropbox-API-Path-Root header value used for specifying
+// that Dropbox API requests should be sent relative to the user's root Dropbox
+// namespace. If a request is sent relative to a namespace that isn't a user's
+// root namespace, then an error occurs.
+func RootNamespace(rootNamespaceID string) *APIPathRoot {
+	return &APIPathRoot{Tag: "root", Root: rootNamespaceID}
 }

--- a/users.go
+++ b/users.go
@@ -70,6 +70,29 @@ func (c *Users) GetAccountBatch(in *GetAccountBatchInput) (out GetAccountBatchOu
 	return
 }
 
+// FullTeam represents a Dropbox team.
+type FullTeam struct {
+	ID                string              `json:"id"`
+	Name              string              `json:"name"`
+	SharingPolicies   TeamSharingPolicies `json:"sharing_policies"`
+	OfficeAddinPolicy struct {
+		Tag string `json:"tag"`
+	} `json:"office_addin_policy"`
+}
+
+// TeamSharingPolicies represents the sharing policies for a Dropbox team.
+type TeamSharingPolicies struct {
+	SharedFolderMemberPolicy struct {
+		Tag string `json:"tag"`
+	} `json:"shared_folder_member_policy"`
+	SharedFolderJoinPolicy struct {
+		Tag string `json:"tag"`
+	} `json:"shared_folder_join_policy"`
+	SharedLinkCreatePolicy struct {
+		Tag string `json:"tag"`
+	} `json:"shared_link_create_policy"`
+}
+
 // GetCurrentAccountOutput request output.
 type GetCurrentAccountOutput struct {
 	AccountID string `json:"account_id"`
@@ -79,14 +102,23 @@ type GetCurrentAccountOutput struct {
 		FamiliarName string `json:"familiar_name"`
 		DisplayName  string `json:"display_name"`
 	} `json:"name"`
-	Email        string `json:"email"`
-	Locale       string `json:"locale"`
-	ReferralLink string `json:"referral_link"`
-	IsPaired     bool   `json:"is_paired"`
-	AccountType  struct {
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	Disabled      bool   `json:"disabled"`
+	Country       string `json:"country"`
+	Locale        string `json:"locale"`
+	ReferralLink  string `json:"referral_link"`
+	TeamMemberID  string `json:"team_member_id"`
+	IsPaired      bool   `json:"is_paired"`
+	AccountType   struct {
 		Tag string `json:".tag"`
 	} `json:"account_type"`
-	Country string `json:"country"`
+	RootInfo struct {
+		Tag             string `json:".tag"`
+		RootNamespaceID string `json:"root_namespace_id"`
+		HomeNamespaceID string `json:"home_namespace_id"`
+		HomePath        string `json:"home_path"`
+	} `json:"root_info"`
 }
 
 // GetCurrentAccount returns information about the current user's account.


### PR DESCRIPTION
This uses the HTTP header `Dropbox-API-Path-Root`, and sending this header allows the caller to interact with files in Dropbox team and shared folders.