### PR TITLE
breaking: add context to all methods, propagating to requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package dropbox
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -28,7 +29,11 @@ func New(config *Config) *Client {
 }
 
 // call rpc style endpoint.
-func (c *Client) call(path string, in interface{}) (io.ReadCloser, error) {
+func (c *Client) call(
+	ctx context.Context,
+	path string,
+	in interface{},
+) (io.ReadCloser, error) {
 	url := "https://api.dropboxapi.com/2" + path
 
 	body, err := json.Marshal(in)
@@ -40,6 +45,7 @@ func (c *Client) call(path string, in interface{}) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
 	req.Header.Set("Content-Type", "application/json")
 	if c.Namespace != nil {
@@ -55,7 +61,12 @@ func (c *Client) call(path string, in interface{}) (io.ReadCloser, error) {
 }
 
 // download style endpoint.
-func (c *Client) download(path string, in interface{}, r io.Reader) (io.ReadCloser, int64, error) {
+func (c *Client) download(
+	ctx context.Context,
+	path string,
+	in interface{},
+	r io.Reader,
+) (io.ReadCloser, int64, error) {
 	url := "https://content.dropboxapi.com/2" + path
 
 	body, err := json.Marshal(in)
@@ -67,6 +78,7 @@ func (c *Client) download(path string, in interface{}, r io.Reader) (io.ReadClos
 	if err != nil {
 		return nil, 0, err
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
 	req.Header.Set("Dropbox-API-Arg", string(body))
 	if c.Namespace != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -1,11 +1,14 @@
 package dropbox
 
 import (
+	"context"
 	"testing"
 
-	"github.com/segmentio/go-env"
+	env "github.com/segmentio/go-env"
 	"github.com/stretchr/testify/assert"
 )
+
+var ctx = context.Background()
 
 func client() *Client {
 	token := env.MustGet("DROPBOX_ACCESS_TOKEN")
@@ -15,7 +18,7 @@ func client() *Client {
 func TestClient_error_text(t *testing.T) {
 	c := client()
 
-	_, err := c.Files.Download(&DownloadInput{
+	_, err := c.Files.Download(ctx, &DownloadInput{
 		Path: "asdfasdfasdf",
 	})
 
@@ -30,7 +33,7 @@ func TestClient_error_text(t *testing.T) {
 func TestClient_error_json(t *testing.T) {
 	c := client()
 
-	_, err := c.Files.Download(&DownloadInput{"/nothing"})
+	_, err := c.Files.Download(ctx, &DownloadInput{"/nothing"})
 	assert.Error(t, err)
 
 	e := err.(*Error)

--- a/error_test.go
+++ b/error_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestError(t *testing.T) {
 	c := client()
-	out, err := c.Files.GetMetadata(&GetMetadataInput{
+	out, err := c.Files.GetMetadata(ctx, &GetMetadataInput{
 		Path: "/this/does/not/exist.txt",
 	})
 

--- a/files.go
+++ b/files.go
@@ -1,6 +1,7 @@
 package dropbox
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"time"
@@ -101,8 +102,8 @@ type GetMetadataOutput struct {
 }
 
 // GetMetadata returns the metadata for a file or folder.
-func (c *Files) GetMetadata(in *GetMetadataInput) (out *GetMetadataOutput, err error) {
-	body, err := c.call("/files/get_metadata", in)
+func (c *Files) GetMetadata(ctx context.Context, in *GetMetadataInput) (out *GetMetadataOutput, err error) {
+	body, err := c.call(ctx, "/files/get_metadata", in)
 	if err != nil {
 		return
 	}
@@ -125,8 +126,8 @@ type CreateFolderOutput struct {
 }
 
 // CreateFolder creates a folder.
-func (c *Files) CreateFolder(in *CreateFolderInput) (out *CreateFolderOutput, err error) {
-	body, err := c.call("/files/create_folder", in)
+func (c *Files) CreateFolder(ctx context.Context, in *CreateFolderInput) (out *CreateFolderOutput, err error) {
+	body, err := c.call(ctx, "/files/create_folder", in)
 	if err != nil {
 		return
 	}
@@ -147,8 +148,8 @@ type DeleteOutput struct {
 }
 
 // Delete a file or folder and its contents.
-func (c *Files) Delete(in *DeleteInput) (out *DeleteOutput, err error) {
-	body, err := c.call("/files/delete", in)
+func (c *Files) Delete(ctx context.Context, in *DeleteInput) (out *DeleteOutput, err error) {
+	body, err := c.call(ctx, "/files/delete", in)
 	if err != nil {
 		return
 	}
@@ -164,8 +165,8 @@ type PermanentlyDeleteInput struct {
 }
 
 // PermanentlyDelete a file or folder and its contents.
-func (c *Files) PermanentlyDelete(in *PermanentlyDeleteInput) (err error) {
-	body, err := c.call("/files/delete", in)
+func (c *Files) PermanentlyDelete(ctx context.Context, in *PermanentlyDeleteInput) (err error) {
+	body, err := c.call(ctx, "/files/delete", in)
 	if err != nil {
 		return
 	}
@@ -186,8 +187,8 @@ type CopyOutput struct {
 }
 
 // Copy a file or folder to a different location.
-func (c *Files) Copy(in *CopyInput) (out *CopyOutput, err error) {
-	body, err := c.call("/files/copy", in)
+func (c *Files) Copy(ctx context.Context, in *CopyInput) (out *CopyOutput, err error) {
+	body, err := c.call(ctx, "/files/copy", in)
 	if err != nil {
 		return
 	}
@@ -209,8 +210,8 @@ type MoveOutput struct {
 }
 
 // Move a file or folder to a different location.
-func (c *Files) Move(in *MoveInput) (out *MoveOutput, err error) {
-	body, err := c.call("/files/move", in)
+func (c *Files) Move(ctx context.Context, in *MoveInput) (out *MoveOutput, err error) {
+	body, err := c.call(ctx, "/files/move", in)
 	if err != nil {
 		return
 	}
@@ -232,8 +233,8 @@ type RestoreOutput struct {
 }
 
 // Restore a file to a specific revision.
-func (c *Files) Restore(in *RestoreInput) (out *RestoreOutput, err error) {
-	body, err := c.call("/files/restore", in)
+func (c *Files) Restore(ctx context.Context, in *RestoreInput) (out *RestoreOutput, err error) {
+	body, err := c.call(ctx, "/files/restore", in)
 	if err != nil {
 		return
 	}
@@ -259,10 +260,10 @@ type ListFolderOutput struct {
 }
 
 // ListFolder returns the metadata for a file or folder.
-func (c *Files) ListFolder(in *ListFolderInput) (out *ListFolderOutput, err error) {
+func (c *Files) ListFolder(ctx context.Context, in *ListFolderInput) (out *ListFolderOutput, err error) {
 	in.Path = normalizePath(in.Path)
 
-	body, err := c.call("/files/list_folder", in)
+	body, err := c.call(ctx, "/files/list_folder", in)
 	if err != nil {
 		return
 	}
@@ -278,8 +279,8 @@ type ListFolderContinueInput struct {
 }
 
 // ListFolderContinue pagenates using the cursor from ListFolder.
-func (c *Files) ListFolderContinue(in *ListFolderContinueInput) (out *ListFolderOutput, err error) {
-	body, err := c.call("/files/list_folder/continue", in)
+func (c *Files) ListFolderContinue(ctx context.Context, in *ListFolderContinueInput) (out *ListFolderOutput, err error) {
+	body, err := c.call(ctx, "/files/list_folder/continue", in)
 	if err != nil {
 		return
 	}
@@ -334,14 +335,14 @@ type SearchOutput struct {
 }
 
 // Search for files and folders.
-func (c *Files) Search(in *SearchInput) (out *SearchOutput, err error) {
+func (c *Files) Search(ctx context.Context, in *SearchInput) (out *SearchOutput, err error) {
 	in.Path = normalizePath(in.Path)
 
 	if in.Mode == "" {
 		in.Mode = SearchModeFilename
 	}
 
-	body, err := c.call("/files/search", in)
+	body, err := c.call(ctx, "/files/search", in)
 	if err != nil {
 		return
 	}
@@ -367,8 +368,8 @@ type UploadOutput struct {
 }
 
 // Upload a file smaller than 150MB.
-func (c *Files) Upload(in *UploadInput) (out *UploadOutput, err error) {
-	body, _, err := c.download("/files/upload", in, in.Reader)
+func (c *Files) Upload(ctx context.Context, in *UploadInput) (out *UploadOutput, err error) {
+	body, _, err := c.download(ctx, "/files/upload", in, in.Reader)
 	if err != nil {
 		return
 	}
@@ -390,8 +391,8 @@ type DownloadOutput struct {
 }
 
 // Download a file.
-func (c *Files) Download(in *DownloadInput) (out *DownloadOutput, err error) {
-	body, l, err := c.download("/files/download", in, nil)
+func (c *Files) Download(ctx context.Context, in *DownloadInput) (out *DownloadOutput, err error) {
+	body, l, err := c.download(ctx, "/files/download", in, nil)
 	if err != nil {
 		return
 	}
@@ -410,7 +411,7 @@ const (
 	GetThumbnailFormatPNG = "png"
 )
 
-// ThumbnailFormat determines the size of the thumbnail.
+// ThumbnailSize determines the size of the thumbnail.
 type ThumbnailSize string
 
 const (
@@ -441,8 +442,8 @@ type GetThumbnailOutput struct {
 
 // GetThumbnail a thumbnail for a file. Currently thumbnails are only generated for the
 // files with the following extensions: png, jpeg, png, tiff, tif, gif and bmp.
-func (c *Files) GetThumbnail(in *GetThumbnailInput) (out *GetThumbnailOutput, err error) {
-	body, l, err := c.download("/files/get_thumbnail", in, nil)
+func (c *Files) GetThumbnail(ctx context.Context, in *GetThumbnailInput) (out *GetThumbnailOutput, err error) {
+	body, l, err := c.download(ctx, "/files/get_thumbnail", in, nil)
 	if err != nil {
 		return
 	}
@@ -465,8 +466,8 @@ type GetPreviewOutput struct {
 // GetPreview a preview for a file. Currently previews are only generated for the
 // files with the following extensions: .doc, .docx, .docm, .ppt, .pps, .ppsx,
 // .ppsm, .pptx, .pptm, .xls, .xlsx, .xlsm, .rtf
-func (c *Files) GetPreview(in *GetPreviewInput) (out *GetPreviewOutput, err error) {
-	body, l, err := c.download("/files/get_preview", in, nil)
+func (c *Files) GetPreview(ctx context.Context, in *GetPreviewInput) (out *GetPreviewOutput, err error) {
+	body, l, err := c.download(ctx, "/files/get_preview", in, nil)
 	if err != nil {
 		return
 	}
@@ -488,8 +489,8 @@ type ListRevisionsOutput struct {
 }
 
 // ListRevisions gets the revisions of the specified file.
-func (c *Files) ListRevisions(in *ListRevisionsInput) (out *ListRevisionsOutput, err error) {
-	body, err := c.call("/files/list_revisions", in)
+func (c *Files) ListRevisions(ctx context.Context, in *ListRevisionsInput) (out *ListRevisionsOutput, err error) {
+	body, err := c.call(ctx, "/files/list_revisions", in)
 	if err != nil {
 		return
 	}
@@ -503,7 +504,6 @@ func (c *Files) ListRevisions(in *ListRevisionsInput) (out *ListRevisionsOutput,
 func normalizePath(s string) string {
 	if s == "/" {
 		return ""
-	} else {
-		return s
 	}
+	return s
 }

--- a/files_test.go
+++ b/files_test.go
@@ -16,7 +16,7 @@ func TestFiles_Upload(t *testing.T) {
 	assert.NoError(t, err, "error opening file")
 	defer file.Close()
 
-	out, err := c.Files.Upload(&UploadInput{
+	out, err := c.Files.Upload(ctx, &UploadInput{
 		Mute:   true,
 		Mode:   WriteModeOverwrite,
 		Path:   "/Readme.md",
@@ -30,7 +30,7 @@ func TestFiles_Upload(t *testing.T) {
 func TestFiles_Download(t *testing.T) {
 	c := client()
 
-	out, err := c.Files.Download(&DownloadInput{"/Readme.md"})
+	out, err := c.Files.Download(ctx, &DownloadInput{"/Readme.md"})
 
 	assert.NoError(t, err, "error downloading")
 	defer out.Body.Close()
@@ -51,7 +51,7 @@ func TestFiles_Download(t *testing.T) {
 func TestFiles_GetMetadata(t *testing.T) {
 	c := client()
 
-	out, err := c.Files.GetMetadata(&GetMetadataInput{
+	out, err := c.Files.GetMetadata(ctx, &GetMetadataInput{
 		Path: "/Readme.md",
 	})
 	assert.NoError(t, err)
@@ -61,7 +61,7 @@ func TestFiles_GetMetadata(t *testing.T) {
 func TestFiles_GetMetadataWithMediaInfo(t *testing.T) {
 	c := client()
 
-	out, err := c.Files.GetMetadata(&GetMetadataInput{
+	out, err := c.Files.GetMetadata(ctx, &GetMetadataInput{
 		Path:             "/IMG_0001.jpg",
 		IncludeMediaInfo: true,
 	})
@@ -75,7 +75,7 @@ func TestFiles_ListFolder(t *testing.T) {
 	t.Parallel()
 	c := client()
 
-	out, err := c.Files.ListFolder(&ListFolderInput{
+	out, err := c.Files.ListFolder(ctx, &ListFolderInput{
 		Path: "/list",
 	})
 
@@ -88,7 +88,7 @@ func TestFiles_ListFolder_root(t *testing.T) {
 	t.Parallel()
 	c := client()
 
-	_, err := c.Files.ListFolder(&ListFolderInput{
+	_, err := c.Files.ListFolder(ctx, &ListFolderInput{
 		Path: "/",
 	})
 
@@ -98,7 +98,7 @@ func TestFiles_ListFolder_root(t *testing.T) {
 func TestFiles_Search(t *testing.T) {
 	c := client()
 
-	out, err := c.Files.Search(&SearchInput{
+	out, err := c.Files.Search(ctx, &SearchInput{
 		Path:  "/",
 		Query: "hello",
 	})
@@ -110,7 +110,7 @@ func TestFiles_Search(t *testing.T) {
 func TestFiles_Delete(t *testing.T) {
 	c := client()
 
-	out, err := c.Files.Delete(&DeleteInput{
+	out, err := c.Files.Delete(ctx, &DeleteInput{
 		Path: "/Readme.md",
 	})
 
@@ -144,7 +144,7 @@ func TestFiles_GetThumbnail(t *testing.T) {
 	// REVIEW(bg): This feels a bit sloppy...
 	{
 		buf := bytes.NewBuffer(grayPng)
-		_, err := c.Files.Upload(&UploadInput{
+		_, err := c.Files.Upload(ctx, &UploadInput{
 			Mute:   true,
 			Mode:   WriteModeOverwrite,
 			Path:   "/gray.png",
@@ -152,7 +152,7 @@ func TestFiles_GetThumbnail(t *testing.T) {
 		})
 		assert.NoError(t, err, "error uploading file")
 	}
-	out, err := c.Files.GetThumbnail(&GetThumbnailInput{"/gray.png", GetThumbnailFormatJPEG, GetThumbnailSizeW32H32})
+	out, err := c.Files.GetThumbnail(ctx, &GetThumbnailInput{"/gray.png", GetThumbnailFormatJPEG, GetThumbnailSizeW32H32})
 	assert.NoError(t, err)
 	if err != nil {
 		return
@@ -173,7 +173,7 @@ func TestFiles_GetThumbnail(t *testing.T) {
 func TestFiles_GetPreview(t *testing.T) {
 	c := client()
 
-	out, err := c.Files.GetPreview(&GetPreviewInput{"/sample.ppt"})
+	out, err := c.Files.GetPreview(ctx, &GetPreviewInput{"/sample.ppt"})
 	defer out.Body.Close()
 
 	assert.NoError(t, err)
@@ -189,7 +189,7 @@ func TestFiles_GetPreview(t *testing.T) {
 func TestFiles_ListRevisions(t *testing.T) {
 	c := client()
 
-	out, err := c.Files.ListRevisions(&ListRevisionsInput{Path: "/sample.ppt"})
+	out, err := c.Files.ListRevisions(ctx, &ListRevisionsInput{Path: "/sample.ppt"})
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, out.Entries)

--- a/sharing.go
+++ b/sharing.go
@@ -1,6 +1,7 @@
 package dropbox
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 )
@@ -48,8 +49,8 @@ const (
 )
 
 // CreateSharedLink returns a shared link.
-func (c *Sharing) CreateSharedLink(in *CreateSharedLinkInput) (out *CreateSharedLinkOutput, err error) {
-	body, err := c.call("/sharing/create_shared_link", in)
+func (c *Sharing) CreateSharedLink(ctx context.Context, in *CreateSharedLinkInput) (out *CreateSharedLinkOutput, err error) {
+	body, err := c.call(ctx, "/sharing/create_shared_link", in)
 	if err != nil {
 		return
 	}
@@ -186,8 +187,8 @@ type InviteeInfo struct {
 }
 
 // ListSharedFileMembers returns shared file membership by its file ID.
-func (c *Sharing) ListSharedFileMembers(in *ListSharedFileMembersInput) (out *ListSharedMembersOutput, err error) {
-	body, err := c.call("/sharing/list_file_members", in)
+func (c *Sharing) ListSharedFileMembers(ctx context.Context, in *ListSharedFileMembersInput) (out *ListSharedMembersOutput, err error) {
+	body, err := c.call(ctx, "/sharing/list_file_members", in)
 	if err != nil {
 		return
 	}
@@ -198,8 +199,8 @@ func (c *Sharing) ListSharedFileMembers(in *ListSharedFileMembersInput) (out *Li
 }
 
 // ListSharedFileMembersContinue returns shared file membership by its file ID.
-func (c *Sharing) ListSharedFileMembersContinue(in *ListSharedMembersContinueInput) (out *ListSharedMembersOutput, err error) {
-	body, err := c.call("/sharing/list_file_members/continue", in)
+func (c *Sharing) ListSharedFileMembersContinue(ctx context.Context, in *ListSharedMembersContinueInput) (out *ListSharedMembersOutput, err error) {
+	body, err := c.call(ctx, "/sharing/list_file_members/continue", in)
 	if err != nil {
 		return
 	}
@@ -210,8 +211,8 @@ func (c *Sharing) ListSharedFileMembersContinue(in *ListSharedMembersContinueInp
 }
 
 // ListSharedFolderMembers returns shared folder membership by its folder ID.
-func (c *Sharing) ListSharedFolderMembers(in *ListSharedFolderMembersInput) (out *ListSharedMembersOutput, err error) {
-	body, err := c.call("/sharing/list_folder_members", in)
+func (c *Sharing) ListSharedFolderMembers(ctx context.Context, in *ListSharedFolderMembersInput) (out *ListSharedMembersOutput, err error) {
+	body, err := c.call(ctx, "/sharing/list_folder_members", in)
 	if err != nil {
 		return
 	}
@@ -222,8 +223,8 @@ func (c *Sharing) ListSharedFolderMembers(in *ListSharedFolderMembersInput) (out
 }
 
 // ListSharedFolderMembersContinue returns shared folder membership by its folder ID.
-func (c *Sharing) ListSharedFolderMembersContinue(in *ListSharedMembersContinueInput) (out *ListSharedMembersOutput, err error) {
-	body, err := c.call("/sharing/list_folder_members/continue", in)
+func (c *Sharing) ListSharedFolderMembersContinue(ctx context.Context, in *ListSharedMembersContinueInput) (out *ListSharedMembersOutput, err error) {
+	body, err := c.call(ctx, "/sharing/list_folder_members/continue", in)
 	if err != nil {
 		return
 	}
@@ -251,8 +252,8 @@ type ListSharedFolderOutput struct {
 }
 
 // ListSharedFolders returns the list of all shared folders the current user has access to.
-func (c *Sharing) ListSharedFolders(in *ListSharedFolderInput) (out *ListSharedFolderOutput, err error) {
-	body, err := c.call("/sharing/list_folders", in)
+func (c *Sharing) ListSharedFolders(ctx context.Context, in *ListSharedFolderInput) (out *ListSharedFolderOutput, err error) {
+	body, err := c.call(ctx, "/sharing/list_folders", in)
 	if err != nil {
 		return
 	}
@@ -268,8 +269,8 @@ type ListSharedFolderContinueInput struct {
 }
 
 // ListSharedFoldersContinue returns the list of all shared folders the current user has access to.
-func (c *Sharing) ListSharedFoldersContinue(in *ListSharedFolderContinueInput) (out *ListSharedFolderOutput, err error) {
-	body, err := c.call("/sharing/list_folders/continue", in)
+func (c *Sharing) ListSharedFoldersContinue(ctx context.Context, in *ListSharedFolderContinueInput) (out *ListSharedFolderOutput, err error) {
+	body, err := c.call(ctx, "/sharing/list_folders/continue", in)
 	if err != nil {
 		return
 	}

--- a/sharing_test.go
+++ b/sharing_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSharing_CreateSharedLink(t *testing.T) {
 	c := client()
-	out, err := c.Sharing.CreateSharedLink(&CreateSharedLinkInput{
+	out, err := c.Sharing.CreateSharedLink(ctx, &CreateSharedLinkInput{
 		Path:     "/hello.txt",
 		ShortURL: true,
 	})
@@ -19,7 +19,7 @@ func TestSharing_CreateSharedLink(t *testing.T) {
 
 func TestSharing_ListSharedFolder(t *testing.T) {
 	c := client()
-	out, err := c.Sharing.ListSharedFolders(&ListSharedFolderInput{
+	out, err := c.Sharing.ListSharedFolders(ctx, &ListSharedFolderInput{
 		Limit: 1,
 	})
 
@@ -29,7 +29,7 @@ func TestSharing_ListSharedFolder(t *testing.T) {
 	assert.NotEmpty(t, out.Entries, "output should be non-empty")
 
 	for out.Cursor != "" {
-		out, err = c.Sharing.ListSharedFoldersContinue(&ListSharedFolderContinueInput{
+		out, err = c.Sharing.ListSharedFoldersContinue(ctx, &ListSharedFolderContinueInput{
 			Cursor: out.Cursor,
 		})
 
@@ -40,7 +40,7 @@ func TestSharing_ListSharedFolder(t *testing.T) {
 	}
 
 	for _, sharedFolder := range shared {
-		out, err := c.Sharing.ListSharedFolderMembers(&ListSharedFolderMembersInput{
+		out, err := c.Sharing.ListSharedFolderMembers(ctx, &ListSharedFolderMembersInput{
 			SharedFolderID: sharedFolder.SharedFolderID,
 			Limit:          1,
 		})
@@ -49,7 +49,7 @@ func TestSharing_ListSharedFolder(t *testing.T) {
 		assert.Equal(t, 1, len(out.Users)+len(out.Groups)+len(out.Invitees), "there should be 1 item present")
 
 		for out.Cursor != "" {
-			out, err = c.Sharing.ListSharedFolderMembersContinue(&ListSharedMembersContinueInput{
+			out, err = c.Sharing.ListSharedFolderMembersContinue(ctx, &ListSharedMembersContinueInput{
 				Cursor: out.Cursor,
 			})
 
@@ -61,7 +61,7 @@ func TestSharing_ListSharedFolder(t *testing.T) {
 
 func TestSharing_ListSharedFile(t *testing.T) {
 	c := client()
-	out, err := c.Sharing.ListSharedFileMembers(&ListSharedFileMembersInput{
+	out, err := c.Sharing.ListSharedFileMembers(ctx, &ListSharedFileMembersInput{
 		File:             "/hello.txt",
 		IncludeInherited: true,
 		Limit:            1,
@@ -71,7 +71,7 @@ func TestSharing_ListSharedFile(t *testing.T) {
 	assert.NotEmpty(t, out.Users, "output should be non-empty")
 	assert.NotEmpty(t, out.Cursor, "cursor should be non-empty for complete test")
 
-	out, err = c.Sharing.ListSharedFileMembersContinue(&ListSharedMembersContinueInput{
+	out, err = c.Sharing.ListSharedFileMembersContinue(ctx, &ListSharedMembersContinueInput{
 		Cursor: out.Cursor,
 	})
 

--- a/users.go
+++ b/users.go
@@ -1,6 +1,7 @@
 package dropbox
 
 import (
+	"context"
 	"encoding/json"
 )
 
@@ -39,8 +40,8 @@ type GetAccountOutput struct {
 }
 
 // GetAccount returns information about a user's account.
-func (c *Users) GetAccount(in *GetAccountInput) (out *GetAccountOutput, err error) {
-	body, err := c.call("/users/get_account", in)
+func (c *Users) GetAccount(ctx context.Context, in *GetAccountInput) (out *GetAccountOutput, err error) {
+	body, err := c.call(ctx, "/users/get_account", in)
 	if err != nil {
 		return
 	}
@@ -59,8 +60,8 @@ type GetAccountBatchInput struct {
 type GetAccountBatchOutput []*GetAccountOutput
 
 // GetAccountBatch returns a list of information about users' accounts.
-func (c *Users) GetAccountBatch(in *GetAccountBatchInput) (out GetAccountBatchOutput, err error) {
-	body, err := c.call("/users/get_account_batch", in)
+func (c *Users) GetAccountBatch(ctx context.Context, in *GetAccountBatchInput) (out GetAccountBatchOutput, err error) {
+	body, err := c.call(ctx, "/users/get_account_batch", in)
 	if err != nil {
 		return
 	}
@@ -122,8 +123,8 @@ type GetCurrentAccountOutput struct {
 }
 
 // GetCurrentAccount returns information about the current user's account.
-func (c *Users) GetCurrentAccount() (out *GetCurrentAccountOutput, err error) {
-	body, err := c.call("/users/get_current_account", nil)
+func (c *Users) GetCurrentAccount(ctx context.Context) (out *GetCurrentAccountOutput, err error) {
+	body, err := c.call(ctx, "/users/get_current_account", nil)
 	if err != nil {
 		return
 	}
@@ -143,8 +144,8 @@ type GetSpaceUsageOutput struct {
 }
 
 // GetSpaceUsage returns space usage information for the current user's account.
-func (c *Users) GetSpaceUsage() (out *GetSpaceUsageOutput, err error) {
-	body, err := c.call("/users/get_space_usage", nil)
+func (c *Users) GetSpaceUsage(ctx context.Context) (out *GetSpaceUsageOutput, err error) {
+	body, err := c.call(ctx, "/users/get_space_usage", nil)
 	if err != nil {
 		return
 	}

--- a/users_test.go
+++ b/users_test.go
@@ -8,18 +8,18 @@ import (
 
 func TestUsers_GetCurrentAccount(t *testing.T) {
 	c := client()
-	_, err := c.Users.GetCurrentAccount()
+	_, err := c.Users.GetCurrentAccount(ctx)
 	assert.NoError(t, err)
 }
 
 func TestUsers_GetAccountBatch(t *testing.T) {
 	c := client()
-	setup, err := c.Users.GetCurrentAccount()
+	setup, err := c.Users.GetCurrentAccount(ctx)
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, setup.AccountID, "account id required for test setup")
 
-	out, err := c.Users.GetAccountBatch(&GetAccountBatchInput{
+	out, err := c.Users.GetAccountBatch(ctx, &GetAccountBatchInput{
 		AccountIDs: []string{setup.AccountID},
 	})
 


### PR DESCRIPTION
This change facilitates improved cancellation patterns
as well as tracing functionality.