### PR TITLE
Support paper crawl endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -17,6 +18,7 @@ type Client struct {
 	Users   *Users
 	Files   *Files
 	Sharing *Sharing
+	Paper   *Paper
 }
 
 // New client.
@@ -25,6 +27,7 @@ func New(config *Config) *Client {
 	c.Users = &Users{c}
 	c.Files = &Files{c}
 	c.Sharing = &Sharing{c}
+	c.Paper = &Paper{c}
 	return c
 }
 
@@ -63,11 +66,12 @@ func (c *Client) call(
 // download style endpoint.
 func (c *Client) download(
 	ctx context.Context,
+	subdomain string,
 	path string,
 	in interface{},
 	r io.Reader,
 ) (io.ReadCloser, int64, error) {
-	url := "https://content.dropboxapi.com/2" + path
+	url := fmt.Sprintf("https://%s.dropboxapi.com/2/%s", subdomain, path)
 
 	body, err := json.Marshal(in)
 	if err != nil {

--- a/files.go
+++ b/files.go
@@ -369,7 +369,7 @@ type UploadOutput struct {
 
 // Upload a file smaller than 150MB.
 func (c *Files) Upload(ctx context.Context, in *UploadInput) (out *UploadOutput, err error) {
-	body, _, err := c.download(ctx, "/files/upload", in, in.Reader)
+	body, _, err := c.download(ctx, "content", "/files/upload", in, in.Reader)
 	if err != nil {
 		return
 	}
@@ -392,7 +392,7 @@ type DownloadOutput struct {
 
 // Download a file.
 func (c *Files) Download(ctx context.Context, in *DownloadInput) (out *DownloadOutput, err error) {
-	body, l, err := c.download(ctx, "/files/download", in, nil)
+	body, l, err := c.download(ctx, "content", "/files/download", in, nil)
 	if err != nil {
 		return
 	}
@@ -443,7 +443,7 @@ type GetThumbnailOutput struct {
 // GetThumbnail a thumbnail for a file. Currently thumbnails are only generated for the
 // files with the following extensions: png, jpeg, png, tiff, tif, gif and bmp.
 func (c *Files) GetThumbnail(ctx context.Context, in *GetThumbnailInput) (out *GetThumbnailOutput, err error) {
-	body, l, err := c.download(ctx, "/files/get_thumbnail", in, nil)
+	body, l, err := c.download(ctx, "content", "/files/get_thumbnail", in, nil)
 	if err != nil {
 		return
 	}
@@ -467,7 +467,7 @@ type GetPreviewOutput struct {
 // files with the following extensions: .doc, .docx, .docm, .ppt, .pps, .ppsx,
 // .ppsm, .pptx, .pptm, .xls, .xlsx, .xlsm, .rtf
 func (c *Files) GetPreview(ctx context.Context, in *GetPreviewInput) (out *GetPreviewOutput, err error) {
-	body, l, err := c.download(ctx, "/files/get_preview", in, nil)
+	body, l, err := c.download(ctx, "content", "/files/get_preview", in, nil)
 	if err != nil {
 		return
 	}

--- a/paper.go
+++ b/paper.go
@@ -170,3 +170,42 @@ func (c *Paper) GetFolderInfo(ctx context.Context, in *PaperGetFolderInfoInput) 
 	err = json.NewDecoder(body).Decode(&out)
 	return
 }
+
+// PaperGetMetadataInput is the request payload format for the alpha
+// /paper/docs/get_metadata requests, indicating the ID of the Dropbox Paper
+// document that the caller wants to get metadata for.
+type PaperGetMetadataInput struct {
+	DocID string `json:"doc_id"`
+}
+
+// PaperGetMetadataOutput is the response format for the alpha
+// /paper/docs/get_metadata endpoint, containing metadata on a Dropbox Paper.
+type PaperGetMetadataOutput struct {
+	DocID           string         `json:"doc_id"`
+	Owner           string         `json:"owner"`
+	Title           string         `json:"title"`
+	CreatedDate     time.Time      `json:"created_date"`
+	Status          PaperDocStatus `json:"status"`
+	Revision        int64          `json:"revision"`
+	LastUpdatedDate time.Time      `json:"last_updated_date"`
+	LastEditor      string         `json:"last_editor"`
+}
+
+// PaperDocStatus contains information about whether a Dropbox Paper is active
+// or deleted.
+type PaperDocStatus struct {
+	Tag string `json:".tag"`
+}
+
+// AlphaGetMetadata returns metadata for the requested file. Note that this
+// is an currently an alpha endpoint, and may disappear.
+func (c *Paper) AlphaGetMetadata(ctx context.Context, in *PaperGetMetadataInput) (out *PaperGetMetadataOutput, err error) {
+	body, err := c.call(ctx, "/paper/get_metadata", in)
+	if err != nil {
+		return
+	}
+	defer body.Close()
+
+	err = json.NewDecoder(body).Decode(&out)
+	return
+}

--- a/paper.go
+++ b/paper.go
@@ -51,10 +51,10 @@ const (
 
 // PaperDocsListInput is the payload for /paper/docs/list requests.
 type PaperDocsListInput struct {
-	FilterBy  string `json:"filter_by"`
-	SortBy    string `json:"sort_by"`
-	SortOrder string `json:"sort_order"`
-	Limit     int    `json:"limit"`
+	FilterBy  string `json:"filter_by,omitempty"`
+	SortBy    string `json:"sort_by,omitempty"`
+	SortOrder string `json:"sort_order,omitempty"`
+	Limit     int    `json:"limit,omitempty"`
 }
 
 // PaperDocsListCursor is a cursor to use in /paper/docs/list/continue calls
@@ -120,7 +120,7 @@ type PaperDownloadInput struct {
 
 // Download a Dropbox Paper.
 func (c *Paper) Download(ctx context.Context, in *PaperDownloadInput) (out *DownloadOutput, err error) {
-	body, l, err := c.download(ctx, "/paper/docs/download", in, nil)
+	body, l, err := c.download(ctx, "api", "/paper/docs/download", in, nil)
 	if err != nil {
 		return
 	}
@@ -140,8 +140,8 @@ type PaperGetFolderInfoInput struct {
 // /paper/docs/get_folder_info requests, containing information on which
 // folders the requested Dropbox Paper is a part of.
 type PaperGetFolderInfoOutput struct {
-	FolderSharingPolicyType PaperFolderSharingPolicyType `json:"folder_sharing_policy_type"`
-	Folders                 []PaperFolder                `json:"folder"`
+	FolderSharingPolicyType PaperFolderSharingPolicyType `json:"folder_sharing_policy_type,omitempty"`
+	Folders                 []PaperFolder                `json:"folders,omitempty"`
 }
 
 // PaperFolderSharingPolicyType is the folder sharing policy for the folder
@@ -200,7 +200,7 @@ type PaperDocStatus struct {
 // AlphaGetMetadata returns metadata for the requested file. Note that this
 // is an currently an alpha endpoint, and may disappear.
 func (c *Paper) AlphaGetMetadata(ctx context.Context, in *PaperGetMetadataInput) (out *PaperGetMetadataOutput, err error) {
-	body, err := c.call(ctx, "/paper/get_metadata", in)
+	body, err := c.call(ctx, "/paper/docs/get_metadata", in)
 	if err != nil {
 		return
 	}

--- a/paper.go
+++ b/paper.go
@@ -1,0 +1,172 @@
+package dropbox
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Paper client for Dropbox Paper.
+type Paper struct {
+	*Client
+}
+
+// NewPaper cretes a new Dropbox Paper client.
+func NewPaper(config *Config) *Paper {
+	return &Paper{
+		Client: &Client{
+			Config: config,
+		},
+	}
+}
+
+const (
+	// PaperDocsFilterAccessed indicates that for this paper/docs/list call we
+	// only want to get documents that the user accessed.
+	PaperDocsFilterAccessed = "docs_accessed"
+	// PaperDocsFilterCreated indicates that for this paper/docs/list call we
+	// only want to get documents that the user created.
+	PaperDocsFilterCreated = "docs_created"
+
+	// PaperDocsSortByAccessed indicates that for this paper/docs/list call we
+	// want to sort the returned doc IDs in the order in which the documents
+	// were accessed by the user
+	PaperDocsSortByAccessed = "accessed"
+	// PaperDocsSortByModified indicates that for this paper/docs/list call we
+	// want to sort the returned doc IDs in the order in which the documents
+	// were modified by any user
+	PaperDocsSortByModified = "modified"
+	// PaperDocsSortByCreated indicates that for this paper/docs/list call we
+	// want to sort the returned doc IDs in the order in which the documents
+	// were created
+	PaperDocsSortByCreated = "created"
+
+	// PaperDocsSortAscending indicates that for this paper/docs/list call we
+	// want to return the doc IDs in ascending order for how they are sorted
+	PaperDocsSortAscending = "ascending"
+	// PaperDocsSortDescending indicates that for this paper/docs/list call we
+	// want to return the doc IDs in decending order for how they are sorted
+	PaperDocsSortDescending = "decending"
+)
+
+// PaperDocsListInput is the payload for /paper/docs/list requests.
+type PaperDocsListInput struct {
+	FilterBy  string `json:"filter_by"`
+	SortBy    string `json:"sort_by"`
+	SortOrder string `json:"sort_order"`
+	Limit     int    `json:"limit"`
+}
+
+// PaperDocsListCursor is a cursor to use in /paper/docs/list/continue calls
+// to continue listing papers where the previous list call left off.
+type PaperDocsListCursor struct {
+	Value      string    `json:"value"`
+	Expiration time.Time `json:"expiration"`
+}
+
+// PaperDocsListOutput is the response format for /paper/docs/list and
+// /paper/docs/list/continue.
+type PaperDocsListOutput struct {
+	DocIDs  []string            `json:"doc_ids"`
+	Cursor  PaperDocsListCursor `json:"cursor"`
+	HasMore bool                `json:"has_more"`
+}
+
+// ListDocs returns the documents in a user's Dropbox Paper.
+func (c *Paper) ListDocs(ctx context.Context, in *PaperDocsListInput) (out *PaperDocsListOutput, err error) {
+	body, err := c.call(ctx, "/paper/docs/list", in)
+	if err != nil {
+		return
+	}
+	defer body.Close()
+
+	err = json.NewDecoder(body).Decode(&out)
+	return
+}
+
+// PaperDocsListContinueInput is the payload for /paper/docs/list/continue
+// requests.
+type PaperDocsListContinueInput struct {
+	Cursor string `json:"cursor"`
+}
+
+// ListDocsContinue paginates using the cursor from ListDocs.
+func (c *Paper) ListDocsContinue(ctx context.Context, in *PaperDocsListContinueInput) (out *PaperDocsListOutput, err error) {
+	body, err := c.call(ctx, "/paper/docs/list/continue", in)
+	if err != nil {
+		return
+	}
+	defer body.Close()
+
+	err = json.NewDecoder(body).Decode(&out)
+	return
+}
+
+const (
+	// ExportFormatHTML indicates that we want to download a Dropbox Paper file
+	// as HTML.
+	ExportFormatHTML = "html"
+	// ExportFormatMarkdown indicates that we want to download a Dropbox Paper
+	// file as Markdown.
+	ExportFormatMarkdown = "markdown"
+)
+
+// PaperDownloadInput is the request format for downloading a Dropbox paper,
+// including the paper's ID and the format we want to download it in.
+type PaperDownloadInput struct {
+	DocID        string `json:"doc_id"`
+	ExportFormat string `json:"export_format"`
+}
+
+// Download a Dropbox Paper.
+func (c *Paper) Download(ctx context.Context, in *PaperDownloadInput) (out *DownloadOutput, err error) {
+	body, l, err := c.download(ctx, "/paper/docs/download", in, nil)
+	if err != nil {
+		return
+	}
+
+	out = &DownloadOutput{body, l}
+	return
+}
+
+// PaperGetFolderInfoInput is the request payload format for
+// /paper/docs/get_folder_info requests, indicating the ID of the Dropbox Paper
+// document that the caller wants to get folder information for.
+type PaperGetFolderInfoInput struct {
+	DocID string `json:"doc_id"`
+}
+
+// PaperGetFolderInfoOutput is the response format for
+// /paper/docs/get_folder_info requests, containing information on which
+// folders the requested Dropbox Paper is a part of.
+type PaperGetFolderInfoOutput struct {
+	FolderSharingPolicyType PaperFolderSharingPolicyType `json:"folder_sharing_policy_type"`
+	Folders                 []PaperFolder                `json:"folder"`
+}
+
+// PaperFolderSharingPolicyType is the folder sharing policy for the folder
+// that contains the requested Drobox Paper; can be either "team or
+// "invite_only".
+type PaperFolderSharingPolicyType struct {
+	Tag string `json:".tag"`
+}
+
+// PaperFolder contains the ID and display name of a folder containing a
+// Dropbox Paper.
+type PaperFolder struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// GetFolderInfo returns information on which folders the requested Dropbox
+// Paper is part of.
+func (c *Paper) GetFolderInfo(ctx context.Context, in *PaperGetFolderInfoInput) (out *PaperGetFolderInfoOutput, err error) {
+	body, err := c.call(ctx, "/paper/docs/get_folder_info", in)
+	if err != nil {
+		return
+	}
+	defer body.Close()
+
+	err = json.NewDecoder(body).Decode(&out)
+	return
+}

--- a/paper_test.go
+++ b/paper_test.go
@@ -2,14 +2,19 @@ package dropbox
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// NOTE: This test assumes that you have 10 or more Papers in your Dropbox
+// Paper directory tree.
 func TestPaper_List(t *testing.T) {
 	ctx := context.Background()
 	c := client()
@@ -26,13 +31,58 @@ func TestPaper_List(t *testing.T) {
 	assert.False(t, out.Cursor.Expiration.IsZero())
 }
 
+func dummyPaperTitle() string { return fmt.Sprintf("go-dropbox-client-test-%d", rand.Intn(100000)) }
+
+func setupPaperDocument(ctx context.Context, t *testing.T, c *Client) (string, func()) {
+	o, err := c.Paper.Create(ctx, &PaperCreateInput{
+		ImportFormat: "markdown",
+		Reader:       strings.NewReader("# " + dummyPaperTitle()),
+	})
+	require.NoError(t, err)
+	return o.DocID, func() {
+		require.NoError(t, c.Paper.PermanentlyDelete(ctx, &PaperPermanentlyDeleteInput{DocID: o.DocID}))
+	}
+}
+
+func TestPaper_CreateDeletePermanently(t *testing.T) {
+	ctx := context.Background()
+	c := client()
+	title := dummyPaperTitle()
+
+	// Create a Dropbox Paper
+	o, err := c.Paper.Create(ctx, &PaperCreateInput{
+		ImportFormat: "markdown",
+		Reader:       strings.NewReader("# " + title),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, o.DocID)
+	assert.Equal(t, title, o.Title)
+	assert.NotZero(t, o.Revision)
+
+	// We should not get an error running GetFolderInfo for this Dropbox Paper
+	// since it exists
+	_, err = c.Paper.GetFolderInfo(ctx, &PaperGetFolderInfoInput{DocID: o.DocID})
+	require.NoError(t, err)
+
+	// Permanently the Dropbox Paper
+	require.NoError(t, c.Paper.PermanentlyDelete(
+		ctx, &PaperPermanentlyDeleteInput{DocID: o.DocID}))
+
+	// GetFolderInfo should now error since this Dropbox Paper no longer exists
+	_, err = c.Paper.GetFolderInfo(ctx, &PaperGetFolderInfoInput{DocID: o.DocID})
+	if assert.Error(t, err) {
+		err, ok := err.(*Error)
+		require.True(t, ok)
+		assert.True(t, strings.HasPrefix(err.Summary, "doc_not_found/"),
+			`error summary %s should have prefix doc_not_found/`)
+	}
+}
+
 func TestPaper_Download(t *testing.T) {
 	ctx := context.Background()
 	c := client()
-	var fileID string
-	if fileID = os.Getenv("DROPBOX_PAPER_TOP_LEVEL_FILE_ID"); fileID == "" {
-		t.Skip("No top-level file ID passed in")
-	}
+	fileID, deleteFile := setupPaperDocument(ctx, t, c)
+	defer deleteFile()
 
 	out, err := c.Paper.Download(ctx, &PaperDownloadInput{
 		DocID:        fileID,
@@ -50,10 +100,8 @@ func TestPaper_GetFolderInfoTopLevel(t *testing.T) {
 	ctx := context.Background()
 	c := client()
 
-	var fileID string
-	if fileID = os.Getenv("DROPBOX_PAPER_TOP_LEVEL_FILE_ID"); fileID == "" {
-		t.Skip("No top-level file ID passed in")
-	}
+	fileID, deleteFile := setupPaperDocument(ctx, t, c)
+	defer deleteFile()
 
 	out, err := c.Paper.GetFolderInfo(ctx, &PaperGetFolderInfoInput{DocID: fileID})
 	require.NoError(t, err)
@@ -61,13 +109,28 @@ func TestPaper_GetFolderInfoTopLevel(t *testing.T) {
 	assert.Nil(t, out.Folders)
 }
 
+// NOTE: This test requires that the caller has a Dropbox Paper file that is
+// nested two folders deep into their Dropbox Paper directory tree, which is
+// set on the environment variable DROPBOX_PAPER_NESTED_FILE_ID. The reason why
+// this cannot be automated the same way creating and testing endpoints on a
+// file at the top level can't is because currently there is no create folder
+// endpoint on the Dropbox Paper API currently, therefore we cannot just create
+// a throwaway folder.
+//
+// If you are running this test and looking for an ID to use, what you can do
+// is run the Dropbox /paper/docs/list endpoint with your OAuth token to get
+// the list of IDs of your Dropbox Papers, then pass those Dropbox IDs to the
+// Dropbox /paper/docs/get_folder_info endpoint until you find one where the
+// endpoint returns two folders. Then set that file's ID as
+// DROPBOX_PAPER_NESTED_FILE_ID.
+
 func TestPaper_GetFolderInfoInsideFolders(t *testing.T) {
 	ctx := context.Background()
 	c := client()
 
 	var fileID string
-	if fileID = os.Getenv("DROPBOX_PAPER_IN_FOLDERS_FILE_ID"); fileID == "" {
-		t.Skip("No top-level file ID passed in")
+	if fileID = os.Getenv("DROPBOX_PAPER_NESTED_FILE_ID"); fileID == "" {
+		t.Skip("No nested file ID passed in")
 	}
 
 	out, err := c.Paper.GetFolderInfo(ctx, &PaperGetFolderInfoInput{DocID: fileID})
@@ -84,10 +147,8 @@ func TestPaper_AlphaGetMetadata(t *testing.T) {
 	ctx := context.Background()
 	c := client()
 
-	var fileID string
-	if fileID = os.Getenv("DROPBOX_PAPER_TOP_LEVEL_FILE_ID"); fileID == "" {
-		t.Skip("No top-level file ID passed in")
-	}
+	fileID, deleteFile := setupPaperDocument(ctx, t, c)
+	defer deleteFile()
 
 	out, err := c.Paper.AlphaGetMetadata(ctx, &PaperGetMetadataInput{DocID: fileID})
 	require.NoError(t, err)

--- a/paper_test.go
+++ b/paper_test.go
@@ -1,0 +1,102 @@
+package dropbox
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaper_List(t *testing.T) {
+	ctx := context.Background()
+	c := client()
+
+	out, err := c.Paper.ListDocs(ctx, &PaperDocsListInput{
+		SortBy:    "modified",
+		SortOrder: "ascending",
+		Limit:     10,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 10, len(out.DocIDs))
+	assert.NotZero(t, out.Cursor.Value)
+	assert.False(t, out.Cursor.Expiration.IsZero())
+}
+
+func TestPaper_Download(t *testing.T) {
+	ctx := context.Background()
+	c := client()
+	var fileID string
+	if fileID = os.Getenv("DROPBOX_PAPER_TOP_LEVEL_FILE_ID"); fileID == "" {
+		t.Skip("No top-level file ID passed in")
+	}
+
+	out, err := c.Paper.Download(ctx, &PaperDownloadInput{
+		DocID:        fileID,
+		ExportFormat: "markdown",
+	})
+	require.NoError(t, err)
+
+	defer out.Body.Close()
+	content, err := ioutil.ReadAll(out.Body)
+	require.NoError(t, err)
+	assert.Equal(t, out.Length, int64(len(content)))
+}
+
+func TestPaper_GetFolderInfoTopLevel(t *testing.T) {
+	ctx := context.Background()
+	c := client()
+
+	var fileID string
+	if fileID = os.Getenv("DROPBOX_PAPER_TOP_LEVEL_FILE_ID"); fileID == "" {
+		t.Skip("No top-level file ID passed in")
+	}
+
+	out, err := c.Paper.GetFolderInfo(ctx, &PaperGetFolderInfoInput{DocID: fileID})
+	require.NoError(t, err)
+	assert.Zero(t, out.FolderSharingPolicyType.Tag)
+	assert.Nil(t, out.Folders)
+}
+
+func TestPaper_GetFolderInfoInsideFolders(t *testing.T) {
+	ctx := context.Background()
+	c := client()
+
+	var fileID string
+	if fileID = os.Getenv("DROPBOX_PAPER_IN_FOLDERS_FILE_ID"); fileID == "" {
+		t.Skip("No top-level file ID passed in")
+	}
+
+	out, err := c.Paper.GetFolderInfo(ctx, &PaperGetFolderInfoInput{DocID: fileID})
+	require.NoError(t, err)
+	assert.Equal(t, "invite_only", out.FolderSharingPolicyType.Tag)
+	require.Len(t, out.Folders, 2)
+	for _, f := range out.Folders {
+		assert.NotZero(t, f.ID)
+		assert.NotZero(t, f.Name)
+	}
+}
+
+func TestPaper_AlphaGetMetadata(t *testing.T) {
+	ctx := context.Background()
+	c := client()
+
+	var fileID string
+	if fileID = os.Getenv("DROPBOX_PAPER_TOP_LEVEL_FILE_ID"); fileID == "" {
+		t.Skip("No top-level file ID passed in")
+	}
+
+	out, err := c.Paper.AlphaGetMetadata(ctx, &PaperGetMetadataInput{DocID: fileID})
+	require.NoError(t, err)
+	assert.Equal(t, fileID, out.DocID)
+	assert.NotZero(t, out.Owner)
+	assert.NotZero(t, out.Title)
+	assert.False(t, out.CreatedDate.IsZero())
+	assert.Equal(t, "active", out.Status.Tag)
+	assert.False(t, out.LastUpdatedDate.IsZero())
+	assert.NotZero(t, out.Revision)
+	assert.NotZero(t, out.LastEditor)
+}


### PR DESCRIPTION
This PR adds support for the Dropbox Paper `docs/list(/continue)?`, download, folder info, and alpha get metadata endpoints